### PR TITLE
feat: add 8am daily pick reminder notification

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -15,6 +15,12 @@ crons.daily(
   api.schedules.schedules
 );
 
+crons.daily(
+  "Send daily pick reminder notification",
+  { hourUTC: 12, minuteUTC: 0 }, // 12:00 UTC, 8am EDT
+  internal.reminders.sendDailyPickReminder
+);
+
 // Weekly pickem advancement - Tuesday 2am Hawaii time (12pm UTC)
 crons.weekly(
   "Advance pickem campaigns to next week and activate matchups",

--- a/convex/reminders.ts
+++ b/convex/reminders.ts
@@ -1,0 +1,35 @@
+"use node";
+import { internalAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+export const sendDailyPickReminder = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const payload = {
+      notification: {
+        title: "🔥 Daily Pick Reminder",
+        message: "Don't forget to make your pick for today's matchups!",
+        icon: "/icons/icon-512x512.png",
+        actions: [{ action: "pick", title: "Make Your Pick" }],
+        data: {
+          onActionClick: {
+            default: {
+              operation: "openWindow",
+              url: "/play",
+            },
+            pick: {
+              operation: "openWindow",
+              url: "/play",
+            },
+          },
+        },
+        clickActionUrl: "/play",
+        tag: "daily-pick-reminder",
+      },
+    };
+
+    await ctx.runAction(internal.notifications.createMassNotification, {
+      payload,
+    });
+  },
+});


### PR DESCRIPTION
This commit introduces a daily push notification to remind users to make their picks. A new cron job is scheduled to run at 8am Eastern Time (12:00 UTC) and triggers an action to send a notification to all users.